### PR TITLE
📑⬆️; separate `votable`; prepend user's new comment

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -14,6 +14,16 @@ Fork this repository,
 work on your fork,
 and submit a pull request.
 
+### Fetch Upstream
+
+After you fetch upstream from your fork,
+you want to run
+
+```shell
+bundle
+./bin/rails db:migrate
+```
+
 ## Style Guide
 
 Please use the formatters mentioned in the [README](./README.md)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Steven He's experiment with Ruby on Rails for a forum
 
-## dependency
+## Dependency
 
-- tailwindcss
+- Tailwindcss
 - Ruby on Rails 7.0.3
 
-## initialize
+## Initialize
 
 `cd` here
 
@@ -18,19 +18,19 @@ solargraph bundle
 rubocop -a
 ```
 
-## development
+## Development
 
-run the server and start tailwindcss
+Run the server and start tailwindcss
 
 ```shell
 ./bin/dev
 ```
 
-the server will be available at port 3000
+The server will be available at port 3000
 
-the text editor I use on this project is visual studio code
+The text editor I use on this project is visual studio code
 
-### formatter
+### Formatter
 
 - aliariff.vscode-erb-beautify
 - heybourn.headwind
@@ -41,7 +41,7 @@ the text editor I use on this project is visual studio code
 The configuration for the formatters are in `.vscode/settings`,
 so please always open the workspace at root level to get the consistent formatting.
 
-### other extension
+### Other extension
 
 - aaron-bond.better-comments
 - streetsidesoftware.code-spell-checker
@@ -55,13 +55,13 @@ so please always open the workspace at root level to get the consistent formatti
 - bung87.vscode-gemfile
 - redhat.vscode-yaml
 
-### testing
+### Testing
 
 ```shell
 ./bin/rails test
 ```
 
-## database
+## Database
 
-the database is sqlite3 for local development
+The database is sqlite3 for local development
 and PostgreSQL for production

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -106,7 +106,7 @@ class PostsController < ApplicationController
   end
 
   def assert_visible
-    redirect_to posts_path unless @post.visible_to? current_user
+    redirect_to posts_path, alert: 'Permission denied.' unless @post.visible_to? current_user
   end
 
   def assert_votable
@@ -114,6 +114,6 @@ class PostsController < ApplicationController
   end
 
   def assert_mutable
-    redirect_to @post unless @post.mutable_to? current_user
+    redirect_to @post, alert: 'Permission denied.' unless @post.mutable_to? current_user
   end
 end

--- a/app/views/comments/_show.html.erb
+++ b/app/views/comments/_show.html.erb
@@ -29,6 +29,9 @@
       <% end %>
     </div>
   </div>
-  <%= turbo_frame_tag comment_dom_id('Comment', comment.id, 0),
-    target: comment_dom_id('Comment', comment.id, 1) %>
+  <% base_id = comment_dom_id('Comment', comment.id, 0) %>
+  <%= turbo_frame_tag base_id,
+    target: comment_dom_id('Comment', comment.id, 1) do %>
+    <span id="<%= base_id %>_comments" class="min-w-full p-5 border rounded-lg empty:hidden"></span>
+  <% end %>
 <% end %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,6 +1,7 @@
-<%= turbo_frame_tag comment_dom_id(@commentable_type, @commentable_id, @offset),
-target: comment_dom_id(@commentable_type, @commentable_id, @offset += 1) do %>
-  <div class="min-w-full p-5 border rounded-lg">
+<% base_id = comment_dom_id(@commentable_type, @commentable_id, @offset) %>
+<%= turbo_frame_tag base_id,
+  target: comment_dom_id(@commentable_type, @commentable_id, @offset += 1) do %>
+  <div id="<%= base_id %>_comments" class="min-w-full p-5 border rounded-lg empty:hidden">
     <% @comments.each do |comment| %>
       <%= render 'show', comment: comment %>
     <% end %>


### PR DESCRIPTION
Improved:
- Documentation
- Separate `votable` to be a set of reusable partials
- Use one route for different votes and displaying votes
- Notice, comment rerendering
Added:
- Prepend new comment that the user just created